### PR TITLE
gog_store directory readme correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,7 @@ Alternatively you can install it using your Linux distro's package manager
 
 ### Authentication
 
-First, you need to obtain data about account `access_token`, `refresh_token` and `user_id`
-
-(for Heroic these can be found in `$HOME/.config/heroic/gog_store/auth.json`)
+You need to obtain `access_token`, `refresh_token` and `user_id` either manually, or by importing them:
 
 #### Via [Heroic Games Launcher](https://github.com/Heroic-Games-Launcher/HeroicGamesLauncher)
 
@@ -73,11 +71,15 @@ Log in to GOG within the launcher. Make sure to launch it before running Comet t
 
 If GOG authentication has never been performed in Heroic on the current user, create the expected directory:
 
-`mkdir -p $HOME/.config/heroic/gog_store/auth.json`
+```
+mkdir -p $HOME/.config/heroic/gog_store
+```
 
 Then, run the command:
 
-`./bin/gogdl --auth-config-path $HOME/.config/heroic/gog_store/auth.json auth --code <code>`
+```
+./bin/gogdl --auth-config-path $HOME/.config/heroic/gog_store/auth.json auth --code <code>
+```
 
 Obtain the code by logging in using this URL, then copying the code value from the resulting URL:
 


### PR DESCRIPTION
The `mkdir` line for the gogdl procedure had the path to the file rather than the directory to be created in.

Also removed the Heroic bit in the beginning of the section and generalised it for use with other GOG clients.

Sorry about the extra pull request earlier, I am not experienced in using git.