### PR TITLE
fix: correct occured->occurred typo in error messages (src/main.rs)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -283,11 +283,11 @@ async fn main() {
                 .await;
 
                 if let Err(err) = web {
-                    error!("Unexpected error occured when downloading web component {err}");
+                    error!("Unexpected error occurred when downloading web component {err}");
                 }
 
                 if let Err(err) = overlay {
-                    error!("Unexpected error occured when downloading overlay component {err}");
+                    error!("Unexpected error occurred when downloading overlay component {err}");
                 }
 
                 log::info!("Done");


### PR DESCRIPTION
Corrected 2 instances of 'occured' → 'occurred' typo in user-facing error messages in src/main.rs (lines 286, 290). These are error!() macro calls shown to users when downloading web/overlay components fails.